### PR TITLE
Use cl-lib function instead of cl.el

### DIFF
--- a/helm-org-rifle.el
+++ b/helm-org-rifle.el
@@ -91,6 +91,7 @@
 (require 'helm)
 (require 'org)
 (require 's)
+(require 'cl-lib)
 
 ;;;; Vars
 
@@ -344,14 +345,14 @@ begins."
               (when (cl-loop with targets = (append (delq nil (list buffer-name
                                                                     heading
                                                                     (when helm-org-rifle-show-tags tags)))
-                                                    (map 'list 'car matching-lines-in-node))
+                                                    (cl-map 'list 'car matching-lines-in-node))
                              for token in input
                              always (and (cl-loop for target in targets
                                                   thereis (s-contains? token target t))))
 
                 ;; Node matches all tokens
                 (setq matched-words-with-context
-                      (cl-loop for line in (map 'list 'car matching-lines-in-node)
+                      (cl-loop for line in (cl-map 'list 'car matching-lines-in-node)
                                append (cl-loop with end
                                                for token in input
                                                for re = (rx-to-string `(and (repeat 0 ,helm-org-rifle-context-characters not-newline)


### PR DESCRIPTION
And load cl-lib.el explicitly. There is a following byte-compile warning about `map`.

```
In end of data:
helm-org-rifle.el:422:1:Warning: the function ‘map’ is not known to be defined.
```