### PR TITLE
Use org-agenda-files *function* to get all org agenda files

### DIFF
--- a/helm-org-rifle.el
+++ b/helm-org-rifle.el
@@ -442,7 +442,7 @@ are searched; they are not filtered with
   "Rifle through Org agenda files."
   ;; This does not need to be defined with helm-org-rifle-define-command because it calls helm-org-rifle-files which is.
   (interactive)
-  (helm-org-rifle-files org-agenda-files))
+  (helm-org-rifle-files (org-agenda-files)))
 
 ;;;###autoload
 (defun helm-org-rifle-directories (&optional directories toggle-recursion)


### PR DESCRIPTION
Hey,

I noticed `helm-org-rifle-agenda-files` wasn't searching directories in `org-agenda-files`. By using the function `org-agenda-files` instead of the variable we can get a complete list of all agenda files, even those inside directory entries in the `org-agenda-files` variable.