### PR TITLE
Replace autoloads for macro calls with static autoload definitions

### DIFF
--- a/helm-org-rifle.el
+++ b/helm-org-rifle.el
@@ -350,7 +350,6 @@ Just in case this is a performance issue for anyone, it can be disabled."
 
 ;;;;; Commands
 
-;;;###autoload
 (cl-defmacro helm-org-rifle-define-command (name args docstring &key sources (let nil) (transformer nil))
   "Define interactive helm-org-rifle command, which will run the appropriate hooks.
 Helm will be called with vars in LET bound."
@@ -375,7 +374,7 @@ Helm will be called with vars in LET bound."
              (helm :sources ,sources)))
        (run-hooks 'helm-org-rifle-after-command-hook))))
 
-;;;###autoload
+;;;###autoload (autoload 'helm-org-rifle "helm-org-rifle" nil t)
 (helm-org-rifle-define-command
  "" ()
  "This is my rifle.  There are many like it, but this one is mine.
@@ -406,13 +405,13 @@ So be it, until victory is ours and there is no enemy, but
 peace!"
  :sources (helm-org-rifle-get-sources-for-open-buffers))
 
-;;;###autoload
+;;;###autoload (autoload 'helm-org-rifle-current-buffer "helm-org-rifle" nil t)
 (helm-org-rifle-define-command
  "current-buffer" ()
  "Rifle through the current buffer."
  :sources (helm-org-rifle-get-source-for-buffer (current-buffer)))
 
-;;;###autoload
+;;;###autoload (autoload 'helm-org-rifle-files "helm-org-rifle" nil t)
 (helm-org-rifle-define-command
  "files" (&optional files)
  "Rifle through FILES, where FILES is a list of paths to Org files.
@@ -439,14 +438,14 @@ are searched; they are not filtered with
                                   (when (helm-attr 'new-buffer source)
                                     (kill-buffer (helm-attr 'buffer source))))))))))
 
-;;;###autoload
+;;;###autoload (autoload 'helm-org-rifle-sort-by-latest-timestamp "helm-org-rifle" nil t)
 (helm-org-rifle-define-command
  "sort-by-latest-timestamp" ()
  "Rifle through open buffers, sorted by latest timestamp."
  :transformer 'helm-org-rifle-transformer-sort-by-latest-timestamp
  :sources (helm-org-rifle-get-sources-for-open-buffers))
 
-;;;###autoload
+;;;###autoload (autoload 'helm-org-rifle-current-buffer-sort-by-latest-timestamp "helm-org-rifle" nil t)
 (helm-org-rifle-define-command
  "current-buffer-sort-by-latest-timestamp" ()
  "Rifle through the current buffer, sorted by latest timestamp."
@@ -493,7 +492,6 @@ Files in DIRECTORIES are filtered using
 
 ;;;;;; Occur commands
 
-;;;###autoload
 (cl-defmacro helm-org-rifle-define-occur-command (name args docstring &key buffers files directories preface)
   "Define `helm-org-rifle-occur' command to search BUFFERS."
   `(defun ,(intern (concat "helm-org-rifle-occur"
@@ -538,20 +536,21 @@ Files in DIRECTORIES are filtered using
                (helm-org-rifle-occur-begin buffers-collected))))
        (run-hooks 'helm-org-rifle-after-command-hook))))
 
-;;;###autoload
+;;;###autoload (autoload 'helm-org-rifle-occur "helm-org-rifle" nil t)
 (helm-org-rifle-define-occur-command
  nil ()
  "Search all Org buffers, showing results in an occur-like, persistent buffer."
  :buffers (--remove (string= helm-org-rifle-occur-results-buffer-name (buffer-name it))
                     (-select 'helm-org-rifle-buffer-visible-p
                              (org-buffer-list nil t))))
-;;;###autoload
+
+;;;###autoload (autoload 'helm-org-rifle-occur-current-buffer "helm-org-rifle" nil t)
 (helm-org-rifle-define-occur-command
  "current-buffer" ()
  "Search current buffer, showing results in an occur-like, persistent buffer."
  :buffers (list (current-buffer)))
 
-;;;###autoload
+;;;###autoload (autoload 'helm-org-rifle-occur-directories "helm-org-rifle" nil t)
 (helm-org-rifle-define-occur-command
  "directories" (&optional directories)
  "Search files in DIRECTORIES, showing results in an occur-like, persistent buffer.
@@ -559,7 +558,7 @@ Files are opened if necessary, and the resulting buffers are left open."
  :directories (or directories
                   (helm-read-file-name "Directories: " :marked-candidates t)))
 
-;;;###autoload
+;;;###autoload (autoload 'helm-org-rifle-occur-files "helm-org-rifle" nil t)
 (helm-org-rifle-define-occur-command
  "files" (&optional files)
  "Search FILES, showing results in an occur-like, persistent buffer.
@@ -567,14 +566,14 @@ Files are opened if necessary, and the resulting buffers are left open."
  :files (or files
             (helm-read-file-name "Files: " :marked-candidates t)))
 
-;;;###autoload
+;;;###autoload (autoload 'helm-org-rifle-occur-agenda-files "helm-org-rifle" nil t)
 (helm-org-rifle-define-occur-command
  "agenda-files" ()
  "Search Org agenda files, showing results in an occur-like, persistent buffer.
 Files are opened if necessary, and the resulting buffers are left open."
  :files (org-agenda-files))
 
-;;;###autoload
+;;;###autoload (autoload 'helm-org-rifle-occur-org-directory "helm-org-rifle" nil t)
 (helm-org-rifle-define-occur-command
  "org-directory" ()
  "Search files in `org-directory', showing results in an occur-like, persistent buffer.


### PR DESCRIPTION
Additionally delete autoloads for the definitions of the macros.
Fixes #13

I stumbled upon this problem now when I noticed that org was loaded by `package-initialize`. By removing every package and adding them one by one again to the elpa-dir and running `(progn (package-initialize) (featurep 'org))` I could find that helm-org-rifle caused the problem.

This seems to fix the problem, as per the discussion in #13.