### PR TITLE
Use derived-mode-p to check the mode

### DIFF
--- a/helm-org-rifle.el
+++ b/helm-org-rifle.el
@@ -1149,7 +1149,7 @@ the (DISPLAY . REAL) pair from
   "Return list of results for INPUT in BUFFER.
 Results is a list of strings with text-properties :NODE-BEG and :BUFFER."
   (with-current-buffer buffer
-    (unless (eq major-mode 'org-mode)
+    (unless (derived-mode-p 'org-mode)
       (error "Buffer %s is not an Org buffer." buffer)))
   (cl-loop for (text . (_ .  pos)) in (helm-org-rifle--get-candidates-in-buffer buffer input)
            collect (list :text text :buffer buffer :node-beg pos)))


### PR DESCRIPTION
Recently, I have started using [org-journal](https://github.com/bastibe/org-journal) which defines a major mode derived from `org-mode`. After I added its journal files to my org agenda files, helm-org-rifle began to raise the following error:

> Buffer 20180515 is not an Org buffer.

So I have implemented this patch to fix the issue. 