### PR TITLE
Fix: Prevent switching the buffer in the original window

### DIFF
--- a/README.org
+++ b/README.org
@@ -99,6 +99,7 @@ Run one of the rifle commands, type some words, and results will be displayed, g
 
 *Fixes*
 +  Use static autoload definitions for macro-defined commands, and delete autoloads for the macro definitions. This prevents =helm-org-rifle= from causing =org= to load unnecessarily.  Fixes #13.  Thanks to Anders Johansson (@andersjohansson) and Chris Ruegge (@cruegge).
++  When opening an item in an indirect buffer, respect the setting of =org-indirect-buffer-display=.  Thanks to [[https://github.com/akirak][Akira Komamura]].
 
 ** 1.5.2
 

--- a/README.org
+++ b/README.org
@@ -99,7 +99,7 @@ Run one of the rifle commands, type some words, and results will be displayed, g
 
 *Fixes*
 +  Use static autoload definitions for macro-defined commands, and delete autoloads for the macro definitions. This prevents =helm-org-rifle= from causing =org= to load unnecessarily.  Fixes #13.  Thanks to Anders Johansson (@andersjohansson) and Chris Ruegge (@cruegge).
-+  When opening an item in an indirect buffer, respect the setting of =org-indirect-buffer-display=.  Thanks to [[https://github.com/akirak][Akira Komamura]].
++  When opening an item in an indirect buffer, respect the setting of =org-indirect-buffer-display=, and preserve position of point in the source buffer.  Thanks to [[https://github.com/akirak][Akira Komamura]].
 
 ** 1.5.2
 

--- a/helm-org-rifle.el
+++ b/helm-org-rifle.el
@@ -709,15 +709,15 @@ source, so we must gather them manually."
   (-let (((buffer . pos) candidate)
          (original-buffer (current-buffer)))
     (helm-attrset 'new-buffer nil)  ; Prevent the buffer from being cleaned up
-    (switch-to-buffer buffer)
-    (goto-char pos)
-    (org-tree-to-indirect-buffer)
-    (unless (equal original-buffer (car (window-prev-buffers)))
-      ;; The selected bookmark was in a different buffer.  Put the
-      ;; non-indirect buffer at the bottom of the prev-buffers list
-      ;; so it won't be selected when the indirect buffer is killed.
-      (set-window-prev-buffers nil (append (cdr (window-prev-buffers))
-                                           (car (window-prev-buffers)))))))
+    (with-current-buffer buffer
+      (goto-char pos)
+      (org-tree-to-indirect-buffer)
+      (unless (equal original-buffer (car (window-prev-buffers)))
+        ;; The selected bookmark was in a different buffer.  Put the
+        ;; non-indirect buffer at the bottom of the prev-buffers list
+        ;; so it won't be selected when the indirect buffer is killed.
+        (set-window-prev-buffers nil (append (cdr (window-prev-buffers))
+                                             (car (window-prev-buffers))))))))
 
 (defun helm-org-rifle-show-entry-in-indirect-buffer-map-action ()
   "Exit Helm buffer and call `helm-org-rifle-show-entry-in-indirect-buffer' with selected candidate."

--- a/helm-org-rifle.el
+++ b/helm-org-rifle.el
@@ -710,14 +710,15 @@ source, so we must gather them manually."
          (original-buffer (current-buffer)))
     (helm-attrset 'new-buffer nil)  ; Prevent the buffer from being cleaned up
     (with-current-buffer buffer
-      (goto-char pos)
-      (org-tree-to-indirect-buffer)
-      (unless (equal original-buffer (car (window-prev-buffers)))
-        ;; The selected bookmark was in a different buffer.  Put the
-        ;; non-indirect buffer at the bottom of the prev-buffers list
-        ;; so it won't be selected when the indirect buffer is killed.
-        (set-window-prev-buffers nil (append (cdr (window-prev-buffers))
-                                             (car (window-prev-buffers))))))))
+      (save-excursion
+        (goto-char pos)
+        (org-tree-to-indirect-buffer)
+        (unless (equal original-buffer (car (window-prev-buffers)))
+          ;; The selected bookmark was in a different buffer.  Put the
+          ;; non-indirect buffer at the bottom of the prev-buffers list
+          ;; so it won't be selected when the indirect buffer is killed.
+          (set-window-prev-buffers nil (append (cdr (window-prev-buffers))
+                                               (car (window-prev-buffers)))))))))
 
 (defun helm-org-rifle-show-entry-in-indirect-buffer-map-action ()
   "Exit Helm buffer and call `helm-org-rifle-show-entry-in-indirect-buffer' with selected candidate."


### PR DESCRIPTION
Hello, I tried to show an entry in an indirect buffer using a rifle command. `org-tree-to-indirect-buffer` determines the window to display a new buffer according to `org-indirect-buffer-display` variable, and it is `other-window` in my setup. The previous implementation mistakenly showed the unnarrowed source buffer in the original window (because it is using `switch-to-buffer`), so I prevent the buffer switching in the original window using `with-current-buffer`. 

I don't exactly understand what `set-window-prev-buffers` is doing here, so I may getting it wrong. Please check it before you merge this PR.