### PR TITLE
Fix: Pass helm-org-rifle-after-init-hook as reference

### DIFF
--- a/README.org
+++ b/README.org
@@ -90,7 +90,8 @@ Run one of the rifle commands, type some words, and results will be displayed, g
 
 ** 1.7.2-pre
 
-Nothing new yet.
+*Fixes*
++ Helm source warning.  ([[https://github.com/alphapapa/org-rifle/pull/77][#77]].  Thanks to [[https://github.com/Thaodan][Björn Bidar]] and [[https://github.com/thierryvolpiatto][Thierry Volpiatto]].)
 
 ** 1.7.1
 

--- a/README.org
+++ b/README.org
@@ -88,6 +88,10 @@ Run one of the rifle commands, type some words, and results will be displayed, g
 
 * Changelog                                                      :noexport_1:
 
+** 1.7.2-pre
+
+Nothing new yet.
+
 ** 1.7.1
 
 *Fixes*

--- a/helm-org-rifle.el
+++ b/helm-org-rifle.el
@@ -2,7 +2,7 @@
 
 ;; Author: Adam Porter <adam@alphapapa.net>
 ;; Url: http://github.com/alphapapa/helm-org-rifle
-;; Version: 1.7.1
+;; Version: 1.7.2-pre
 ;; Package-Requires: ((emacs "24.4") (dash "2.12") (f "0.18.1") (helm "1.9.4") (s "1.10.0"))
 ;; Keywords: hypermedia, outlines
 

--- a/helm-org-rifle.el
+++ b/helm-org-rifle.el
@@ -705,7 +705,7 @@ Files are opened if necessary, and the resulting buffers are left open."
 (defun helm-org-rifle-get-source-for-buffer (buffer)
   "Return Helm source for BUFFER."
   (let ((source (helm-build-sync-source (buffer-name buffer)
-                  :after-init-hook helm-org-rifle-after-init-hook
+                  :after-init-hook 'helm-org-rifle-after-init-hook
                   :candidates (lambda ()
                                 (when (s-present? helm-pattern)
                                   (helm-org-rifle--get-candidates-in-buffer (helm-attr 'buffer) helm-pattern)))


### PR DESCRIPTION
helm-org-rifle-after-init-hook was passed as string. Helm sends a
warning when ~after-init-hook~ is not a symbol during functions such as ~helm-org-rifle~:
Warning (emacs): Helm source ‘file.org’: after-init-hook Should be defined as a symbol